### PR TITLE
function-based offset and defaultOptions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,19 @@ link: function($scope, $elem, $attrs){
 
 #### duration
 Type: `Integer`
-Default: `0`
+Default: `800`
 
 The duration of the smooth scroll, in miliseconds.
 
 #### offset
-Type: `Integer`
-Default: `800`
+Type: `Integer` or `Function` or `Element`
+Default: `0`
 
 The offset from the top of the page in which the scroll should stop.
+
+If the value specified is a `Function`, it is called as `offset = offset(element, options);` where the result may an `Integer` or `Element`
+
+If the value specified is an `Element` (native or jqLite), its `offsetHeight` will be used
 
 #### easing
 type: `string`

--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -112,17 +112,35 @@
 		}, 0);
 	};
 
-
-	// Expose the library in a factory
+	// Expose the library via a provider to allow default options to be overridden
 	//
-	module.factory('smoothScroll', function() {
-		return smoothScroll;
+	module.provider('smoothScroll', function() {
+		
+		function noop() {}
+		var defaultOptions = {
+			duration: 800,
+			offset: 0,
+			easing: 'easeInOutQuart',
+			callbackBefore: noop,
+			callbackAfter: noop
+		};
+
+		return {
+			$get: function() {
+				return function(element, options) {
+					smoothScroll(element, angular.extend({}, defaultOptions, options));
+				}
+			},
+			setDefaultOptions: function(options) {
+				angular.extend(defaultOptions, options);
+			}
+		}
 	});
 	
 
 	// Scrolls the window to this element, optionally validating an expression
 	//
-	module.directive('smoothScroll', ['smoothScroll', function(smoothScroll) {
+	module.directive('smoothScroll', ['smoothScroll', function(smoothScroll, smoothScrollProvider) {
 		return {
 			restrict: 'A',
 			scope: {
@@ -151,13 +169,21 @@
 							}
 						};
 
-						smoothScroll($elem[0], {
-							duration: $attrs.duration,
-							offset: $attrs.offset,
-							easing: $attrs.easing,
+						var options = {
 							callbackBefore: callbackBefore,
 							callbackAfter: callbackAfter
-						});
+						};
+
+						if (typeof $attrs.duration != 'undefined')
+							options.duration = $attrs.duration;
+
+						if (typeof $attrs.offset != 'undefined')
+							options.offset = $attrs.offset;
+
+						if (typeof $attrs.easing != 'undefined')
+							options.easing = $attrs.easing;
+
+						smoothScroll($elem[0], options);
 					}, 0);
 				}
 			}
@@ -200,14 +226,22 @@
 							}
 						}
 					};
-
-					smoothScroll(targetElement, {
-						duration: $attrs.duration,
-						offset: $attrs.offset,
-						easing: $attrs.easing,
+					
+					var options = {
 						callbackBefore: callbackBefore,
 						callbackAfter: callbackAfter
-					});
+					};
+
+					if (typeof $attrs.duration != 'undefined')
+						options.duration = $attrs.duration;
+
+					if (typeof $attrs.offset != 'undefined')
+						options.offset = $attrs.offset;
+
+					if (typeof $attrs.easing != 'undefined')
+						options.easing = $attrs.easing;
+
+					smoothScroll(targetElement, options);
 
 					return false;
 				});

--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -28,6 +28,19 @@
 
 	var module = angular.module('smoothScroll', []);
 
+	var resolveOffset = function(offset, element, options) {
+		if (typeof offset == 'function')
+			offset = offset(element, options);
+
+		if (angular.isElement(offset)) {
+			var offsetEl = angular.element(offset)[0];
+
+			if (typeof offset != 'undefined')
+				offset = offsetEl.offsetHeight;
+		}
+
+		return offset;
+	}
 
 	// Smooth scrolls the window to the provided element.
 	//
@@ -36,10 +49,12 @@
 
 		// Options
 		var duration = options.duration || 800,
-			offset = options.offset || 0,
+			offset = resolveOffset(options.offset || 0, element, options),
 			easing = options.easing || 'easeInOutQuart',
 			callbackBefore = options.callbackBefore || function() {},
 			callbackAfter = options.callbackAfter || function() {};
+
+		
 			
 		var getScrollLocation = function() {
 			return window.pageYOffset ? window.pageYOffset : document.documentElement.scrollTop;


### PR DESCRIPTION
We had a need to calculate the offset, globally, at runtime in order to deal with a sticky header.

To handle the "global" nature, I converted the primary factory into a provider which merges the supplied options with the defaults. The provider can be injected into a `config()` handler, whereby `setDefaultOptions` will merge any custom defaults into the main set.

The second change was to resolve the offset depending on the type (function, element, other).

There should be no compatibility issues with either change, as it compatible with previous usage patterns.