### PR TITLE
Correctly determine document height cross browser

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -123,7 +123,7 @@
 			var stopAnimation = function () {
 				var currentLocation = getScrollLocation(),
 					documentHeight = getDocHeight();
-				if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= documentHeight ) ) {
+				if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) > documentHeight ) ) {
 					if (options.stopOnUserScroll) {
 						scrollableElements.off('wheel', userScrollListener);
 					}

--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -54,8 +54,8 @@
 			callbackBefore = options.callbackBefore || function() {},
 			callbackAfter = options.callbackAfter || function() {};
 
-		
-			
+
+
 		var getScrollLocation = function() {
 			return window.pageYOffset ? window.pageYOffset : document.documentElement.scrollTop;
 		};
@@ -82,6 +82,14 @@
 				return time; // no easing, no acceleration
 			};
 
+			// Get document height
+			var getDocHeight = function() {
+				return Math.max(
+					document.body.scrollHeight, document.documentElement.scrollHeight,
+					document.body.offsetHeight, document.documentElement.offsetHeight,
+					document.body.clientHeight, document.documentElement.clientHeight
+				);
+			}
 
 			// Calculate how far to scroll
 			var getEndLocation = function (element) {
@@ -113,8 +121,9 @@
 
 			// Stop the scrolling animation when the anchor is reached (or at the top/bottom of the page)
 			var stopAnimation = function () {
-				var currentLocation = getScrollLocation();
-				if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= document.body.scrollHeight ) ) {
+				var currentLocation = getScrollLocation(),
+					documentHeight = getDocHeight();
+				if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= documentHeight ) ) {
 					if (options.stopOnUserScroll) {
 						scrollableElements.off('wheel', userScrollListener);
 					}
@@ -144,7 +153,7 @@
 	// Expose the library via a provider to allow default options to be overridden
 	//
 	module.provider('smoothScroll', function() {
-		
+
 		function noop() {}
 		var defaultOptions = {
 			duration: 800,
@@ -165,7 +174,7 @@
 			}
 		}
 	});
-	
+
 
 	// Scrolls the window to this element, optionally validating an expression
 	//
@@ -231,13 +240,13 @@
 			},
 			link: function($scope, $elem, $attrs) {
 				var targetElement;
-				
+
 				$elem.on('click', function(e) {
 					e.preventDefault();
 
 					targetElement = document.getElementById($attrs.scrollTo);
-					if ( !targetElement ) return; 
-					
+					if ( !targetElement ) return;
+
 					var callbackBefore = function(element) {
 						if ( $attrs.callbackBefore ) {
 							var exprHandler = $scope.callbackBefore({element: element});
@@ -255,7 +264,7 @@
 							}
 						}
 					};
-					
+
 					var options = {
 						callbackBefore: callbackBefore,
 						callbackAfter: callbackAfter


### PR DESCRIPTION
This addresses an issue where in Firefox the scrolling would stop if you were at the bottom of your page, while the element you're scrolling to was at the top of the page with a top margin. Firefox doesn't add the margin to document.body.scrollHeight, so the height reported was less than the actual document height, causing the smooth scroll to stop after the first iteration.

Furthermore, the >= comparison has been replaced with >, because when at the bottom of the page, and wanting to scroll up, the equal comparison would prevent scroll from happening.