### PR TITLE
Fix issue #21 "When page is scrolled to the bottom, scroll-to does no…

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -102,6 +102,7 @@
 				distance 		= endLocation - startLocation,
 				percentage,
 				position,
+				positionDelta,
 				scrollHeight,
 				internalHeight;
 
@@ -141,7 +142,10 @@
 				timeLapsed += 16;
 				percentage = ( timeLapsed / duration );
 				percentage = ( percentage > 1 ) ? 1 : percentage;
-				position = startLocation + ( distance * getEasingPattern(easing, percentage) );
+				positionDelta = distance * getEasingPattern(easing, percentage);
+				// Force at least 1px movement per scroll animation update
+				positionDelta = (positionDelta >= 0) ? Math.ceil(positionDelta) : Math.floor(positionDelta);
+				position = startLocation + positionDelta;
 				if(containerPresent) {
 					container.scrollTop = position;
 				} else {


### PR DESCRIPTION
Discussed here: https://github.com/d-oliveros/ngSmoothScroll/issues/21

This issue occurs whenever the container or window is already scrolled
to the bottom and the easing method causes less than 1px of scrolling
for the first scroll animation update.

My fix works by requiring at least 1px of scrolling per animation
update. This causes the stopAnimation check to always pass instead of
prematurely failing on the first scroll animation update.
