### PR TITLE
add protection against missing element

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -83,7 +83,7 @@
 		 */
 		var getEndLocation = function(element) {
 			var location = 0;
-			if (element.offsetParent) {
+			if (element && element.offsetParent) {
 				do {
 					location += element.offsetTop;
 					element = element.offsetParent;


### PR DESCRIPTION
if the element doesn't exist you get an 'offsetParent undefined' by adding an extra check for element you don't get this error and it will default to a location of 0
