### PR TITLE
Fix getEndLocation: Wrong max. scroll position

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -90,6 +90,11 @@
 				} while (element);
 			}
 			location = Math.max(location - offset, 0);
+			/*
+			 * If element location is at the bottom and withing the last window height, then we have to set end location to the highest possible and valid scroll position.
+			 * This fixes the problem that animated scrolls are abruptedly stopped because the location was higher than the latest possible scroll location.
+			 */
+			location = Math.min(location, document.body.scrollHeight - window.innerHeight);
 			return location;
 		};
 


### PR DESCRIPTION
If element location is at the bottom and withing the last window height, then we have to set end location to the highest possible and valid scroll position.
This fixes the problem that animated scrolls are abruptly stopped because the location was higher than the latest possible scroll location.