### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bower install ngSmoothScroll
 
 This module provides two directives:
 
-####smoothScroll:
+#### smoothScroll:
 
 Attribute. Scrolls the window to this element, optionally validating the expression inside scroll-if.
 
@@ -75,7 +75,7 @@ Example:
 </div>
 ```
 
-####scrollTo:
+#### scrollTo:
 
 Attribute. Scrolls the window to the specified element ID when clicking this element.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
