### PR TITLE
Fix to calculate correct scroll position if container is provided

### DIFF
--- a/lib/angular-smooth-scroll.js
+++ b/lib/angular-smooth-scroll.js
@@ -87,7 +87,7 @@
 				do {
 					location += element.offsetTop;
 					element = element.offsetParent;
-				} while (element);
+				} while (element && element !== container);
 			}
 			location = Math.max(location - offset, 0);
 			return location;


### PR DESCRIPTION
If custom container if provided, the value of `location` is calculated incorrectly. Loop goes up to root element and adds up all offsetTop values. It should stop at the container provided and do not include parent element offsetTop values.